### PR TITLE
ci(tombi): add the `--error-on-warnings` linter arg

### DIFF
--- a/.github/insight.toml
+++ b/.github/insight.toml
@@ -6,6 +6,7 @@ check_title = true
 
 [args.linters]
 yamllint = ["--strict"]
+tombi = ["--error-on-warnings"]
 
 [formatters]
 prettier = ["**/*.yml", "**/*.json"]


### PR DESCRIPTION
Signed-off-by: Shigure Kurosaki <shigure@hqsy.net>

<!--

Thanks for opening a PR! Your contribution is much appreciated.

NOTE: We encourage you to provide as much detail as possible.

-->

<!-- markdownlint-disable-file MD041 -->

### Summary of Changes

<!-- Please include a summary of the changes -->

1. CHANGE_SUMMARY

### Description

<!-- Explain the reason for the changes -->

- **What does this PR do?**
  - EXPLAIN_HERE
- **Does this introduce breaking changes?**
  - EXPLAIN_HERE

### Checklist

<!-- Please check the following before submitting the PR -->

- [ ] I have updated the CI pipeline.
- [x] I have reviewed my changes.

### Additional Notes

<!-- Any additional information -->

https://github.com/tombi-toml/tombi/pull/1263
