### PR TITLE
ci: move CodeQL and Insight out of `ci.yml`

### DIFF
--- a/.github/insight.toml
+++ b/.github/insight.toml
@@ -1,11 +1,6 @@
 [match]
 dot = true
 
-[pr]
-check-title = true
-# https://codeql.github.com/docs/codeql-overview/supported-languages-and-frameworks/#languages-and-compilers
-detect-changes = [{ actions = [".github/workflows/*.yml"] }]
-
 [args.linters]
 yamllint = ["--strict"]
 tombi = ["--error-on-warnings"]

--- a/.github/workflows/check-pull-request-title.yml
+++ b/.github/workflows/check-pull-request-title.yml
@@ -16,6 +16,8 @@ jobs:
     name: Insight
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Run Insight
         uses: arghena/insight@632f721ddf36ecfc9c5d137e70e200b17209e5ad # v0.1.0-canary.20
         with:

--- a/.github/workflows/check-pull-request-title.yml
+++ b/.github/workflows/check-pull-request-title.yml
@@ -1,12 +1,12 @@
-name: CI
+name: Check Pull Request Title
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, edited]
 
 permissions:
   contents: read
@@ -16,7 +16,7 @@ jobs:
     name: Insight
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Run Insight
         uses: arghena/insight@632f721ddf36ecfc9c5d137e70e200b17209e5ad # v0.1.0-canary.20
+        with:
+          check-pull-request-title: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,40 @@
+name: CodeQL
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  pull_request:
+    # https://codeql.github.com/docs/codeql-overview/supported-languages-and-frameworks/#languages-and-compilers
+    paths:
+      - '.github/workflows/*.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  codeql:
+    permissions:
+      contents: read
+      security-events: write
+    name: Run CodeQL
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@5d4e8d1aca955e8d8589aabd499c5cae939e33c7 # v4.31.9
+        with:
+          build-mode: none
+          queries: security-extended,security-and-quality
+          languages: actions
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@5d4e8d1aca955e8d8589aabd499c5cae939e33c7 # v4.31.9
+        with:
+          # NOTE:
+          # Delete all the old dynamic analysis to get it back to work.
+          # https://github.com/github/codeql-action/issues/1179#issuecomment-2050937338
+          category: '/language:actions'


### PR DESCRIPTION
Signed-off-by: Shigure Kurosaki <shigure@hqsy.net>

<!--

Thanks for opening a PR! Your contribution is much appreciated.

NOTE: We encourage you to provide as much detail as possible.

-->

<!-- markdownlint-disable-file MD041 -->

### Summary of Changes

<!-- Please include a summary of the changes -->

1. ci(codeql): moved CodeQL from `ci.yml` to `codeql.yml`
2. ci(insight): migrate PR title check config to `check-pull-request-title.yml`
3. ci(deps): bump arghena/insight from 0.1.0-canary.19 to 0.1.0-canary.20

### Description

<!-- Explain the reason for the changes -->

- **What does this PR do?**
  - EXPLAIN_HERE
- **Does this introduce breaking changes?**
  - EXPLAIN_HERE

### Checklist

<!-- Please check the following before submitting the PR -->

- [ ] I have updated the CI pipeline.
- [x] I have reviewed my changes.

### Additional Notes

<!-- Any additional information -->
