### PR TITLE
ci(deps): bump arghena/insight from 0.1.0-canary.27 to 0.1.0-canary.28

### DIFF
--- a/.github/workflows/check-pull-request-title.yml
+++ b/.github/workflows/check-pull-request-title.yml
@@ -20,6 +20,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Run Insight
-        uses: arghena/insight@6642f76496937519c45c122f6218fa0a2dc07fd2 # v0.1.0-canary.27
+        uses: arghena/insight@b1e35ecda6126d31c0149ee99e774e14975c5562 # v0.1.0-canary.28
         with:
           check-pull-request-title: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,4 +19,4 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Run Insight
-        uses: arghena/insight@6642f76496937519c45c122f6218fa0a2dc07fd2 # v0.1.0-canary.27
+        uses: arghena/insight@b1e35ecda6126d31c0149ee99e774e14975c5562 # v0.1.0-canary.28


### PR DESCRIPTION
Signed-off-by: Shigure Kurosaki <shigure@hqsy.net>

<!--

Thanks for opening a PR! Your contribution is much appreciated.

NOTE: We encourage you to provide as much detail as possible.

-->

<!-- markdownlint-disable-file MD041 -->

### Summary of Changes

<!-- Please include a summary of the changes -->

1. CHANGE_SUMMARY

### Description

<!-- Explain the reason for the changes -->

- **What does this PR do?**
  - EXPLAIN_HERE
- **Does this introduce breaking changes?**
  - EXPLAIN_HERE

### Checklist

<!-- Please check the following before submitting the PR -->

- [ ] I have updated the CI pipeline.
- [x] I have reviewed my changes.

### Additional Notes

<!-- Any additional information -->
