### PR TITLE
ci: bump `insight` to canary.55 and enable `zizmor`

### DIFF
--- a/.github/insight.toml
+++ b/.github/insight.toml
@@ -9,6 +9,7 @@ tombi = ["**/*.toml"]
 typos = ["**/*", "![a-z-]+/**"]
 yamllint = ["**/*.yml"]
 actionlint = [".github/workflows/*.yml"]
+zizmor = [".github/workflows/*.yml", ".github/dependabot.yml"]
 tombi = ["**/*.toml"]
 
 [args.linters]

--- a/.github/workflows/check-pull-request-title.yml
+++ b/.github/workflows/check-pull-request-title.yml
@@ -18,6 +18,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run Insight
-        uses: arghena/insight@5ea677a3665dacea83699c18841170f5261e0008 # v0.1.0-canary.54
+        uses: arghena/insight@8cc65ddff8c3d2b20647171ef489824c88889357 # v0.1.0-canary.55
         with:
           check-pull-request-title: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,4 +21,4 @@ jobs:
         with:
           persist-credentials: false
       - name: Run Insight
-        uses: arghena/insight@5ea677a3665dacea83699c18841170f5261e0008 # v0.1.0-canary.54
+        uses: arghena/insight@8cc65ddff8c3d2b20647171ef489824c88889357 # v0.1.0-canary.55


### PR DESCRIPTION
Signed-off-by: Shigure Kurosaki <shigure@hqsy.net>

<!-- markdownlint-disable-file MD041 -->

### Summary of Changes

<!-- Please include a summary of the changes -->

1. CHANGE_SUMMARY

### Description

<!-- Explain the reason for the changes -->

- **What does this PR do?**
  - EXPLAIN_HERE
- **Does this introduce breaking changes?**
  - EXPLAIN_HERE

### Additional Notes

<!-- Any additional information -->
