### PR TITLE
ci: bump dependencies

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,7 +20,7 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
       - name: Setup Node and pnpm
-        uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
+        uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
         with:
           runtime: node@lts
           version: latest

--- a/.github/workflows/check-pull-request-title.yml
+++ b/.github/workflows/check-pull-request-title.yml
@@ -18,6 +18,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run Insight
-        uses: arghena/insight@8cc65ddff8c3d2b20647171ef489824c88889357 # v0.1.0-canary.55
+        uses: arghena/insight@2b2f5097b7d9e1ce56bc8a025d3987df3ff054e0 # v0.1.0-canary.56
         with:
           check-pull-request-title: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           build-mode: none
           # https://codeql.github.com/codeql-query-help
@@ -42,7 +42,7 @@ jobs:
           queries: security-and-quality
           languages: actions
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           # NOTE: Delete all the old dynamic analysis to get it back to work.
           # https://github.com/github/codeql-action/issues/1179#issuecomment-2050937338

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,4 +21,4 @@ jobs:
         with:
           persist-credentials: false
       - name: Run Insight
-        uses: arghena/insight@8cc65ddff8c3d2b20647171ef489824c88889357 # v0.1.0-canary.55
+        uses: arghena/insight@2b2f5097b7d9e1ce56bc8a025d3987df3ff054e0 # v0.1.0-canary.56


### PR DESCRIPTION
Signed-off-by: Shigure Kurosaki <shigure@hqsy.net>

<!-- markdownlint-disable-file MD041 -->

### Summary of Changes

<!-- Please include a summary of the changes -->

```diff
.github/workflows/cd.yml:23
-         uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
+         uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
.github/workflows/check-pull-request-title.yml:21
-         uses: arghena/insight@8cc65ddff8c3d2b20647171ef489824c88889357 # v0.1.0-canary.55
+         uses: arghena/insight@2b2f5097b7d9e1ce56bc8a025d3987df3ff054e0 # v0.1.0-canary.56
.github/workflows/codeql.yml:37
-         uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+         uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
.github/workflows/codeql.yml:45
-         uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+         uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
.github/workflows/lint.yml:24
-         uses: arghena/insight@8cc65ddff8c3d2b20647171ef489824c88889357 # v0.1.0-canary.55
+         uses: arghena/insight@2b2f5097b7d9e1ce56bc8a025d3987df3ff054e0 # v0.1.0-canary.56
```

### Description

<!-- Explain the reason for the changes -->

- **What does this PR do?**
  - EXPLAIN_HERE
- **Does this introduce breaking changes?**
  - EXPLAIN_HERE

### Additional Notes

<!-- Any additional information -->
